### PR TITLE
Fixes packet infinite loop if someone sends NaN data.

### DIFF
--- a/src/CVector.h
+++ b/src/CVector.h
@@ -116,6 +116,11 @@ public:
 		return ret;
 	}
 
+	bool IsNan(void)
+	{
+		return (fX != fX || fY != fY || fZ != fZ);
+	}
+
 	CVector operator + ( const CVector& vecRight ) const
 	{
 		return CVector ( fX + vecRight.fX, fY + vecRight.fY, fZ + vecRight.fZ );

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -175,6 +175,18 @@ static BYTE HOOK_GetPacketID(Packet *p)
 	if (packetId == ID_PLAYER_SYNC) {
 		CSyncData *d = (CSyncData*)(&p->data[1]);
 
+		// NAN stuff = inf loop, no idea why.
+		// This prevents it though, so I didn't bother to look too deep into it.
+		if (d->vecPosition.IsNan() ||
+			d->vecQuaternion.IsNan() ||
+			d->vecSurfing.IsNan() ||
+			d->vecVelocity.IsNan() ||
+			d->fQuaternionAngle != d->fQuaternionAngle)
+		{
+			subhook_install(GetPacketID_hook);
+			return packetId;
+		}
+
 		if (disableSyncBugs) {
 			// Prevent "ghost shooting" bugs
 			if ((d->byteWeapon >= WEAPON_COLT45 && d->byteWeapon <= WEAPON_SNIPER) || d->byteWeapon == WEAPON_MINIGUN)
@@ -397,6 +409,12 @@ static BYTE HOOK_GetPacketID(Packet *p)
 
 	if (packetId == ID_AIM_SYNC) {
 		CAimSyncData *d = (CAimSyncData*)(&p->data[1]);
+
+		// Never had an issue with getting crashed here, but... better to check.
+		if (d->vecFront.IsNan() || d->vecPosition.IsNan()) {
+			subhook_install(GetPacketID_hook);
+			return packetId;
+		}
 
 		// Fix first-person up/down aim sync
 		if (lastWeapon[playerid] == 34 || lastWeapon[playerid] == 35 || lastWeapon[playerid] == 36 || lastWeapon[playerid] == 43) {


### PR DESCRIPTION
Aim & Foot sync should be protected now. SA-MP seems to handle the packets fine and disregards them, so they just get passed back to SA-MP. 
For unknown reasons the server got into a loop with invalid foot data, I don't know if this was because of weapon-config or some other include using SKY or SKY itself.
Code is meh, if you want me to change anything let me know.
Has been tested on production servers beforehand, a COD server being one, it helped before they found another way that is not to do with SKY.