### PR TITLE
Fix GetPacketID assertion failure in src/Hooks.cpp

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -140,16 +140,20 @@ static bool IsPlayerUpdatePacket(unsigned char packetId)
 
 BYTE GetPacketID(Packet *p)
 {
-	if (p == 0)
-		return 255;
+    if (p == nullptr)
+        return 255;
 
-	if ((unsigned char)p->data[0] == ID_TIMESTAMP)
-	{
-		assert(p->length > sizeof(unsigned char) + sizeof(unsigned long));
-		return (unsigned char)p->data[sizeof(unsigned char) + sizeof(unsigned long)];
-	}
-	else
-		return (unsigned char)p->data[0];
+    if ((unsigned char)p->data[0] == ID_TIMESTAMP)
+    {
+        if (p->length <= sizeof(unsigned char) + sizeof(unsigned long))
+		{
+			logprintf("Invalid Packet Length");  //here
+			return 255;
+		}         
+        return (unsigned char)p->data[sizeof(unsigned char) + sizeof(unsigned long)];
+    }
+    else
+        return (unsigned char)p->data[0];
 }
 //----------------------------------------------------
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -146,10 +146,9 @@ BYTE GetPacketID(Packet *p)
     if ((unsigned char)p->data[0] == ID_TIMESTAMP)
     {
         if (p->length <= sizeof(unsigned char) + sizeof(unsigned long))
-		{
-			return 255;
-		}         
-        return (unsigned char)p->data[sizeof(unsigned char) + sizeof(unsigned long)];
+			return 255;   
+        
+		return (unsigned char)p->data[sizeof(unsigned char) + sizeof(unsigned long)];
     }
     else
         return (unsigned char)p->data[0];

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -147,7 +147,6 @@ BYTE GetPacketID(Packet *p)
     {
         if (p->length <= sizeof(unsigned char) + sizeof(unsigned long))
 		{
-			logprintf("Invalid Packet Length");  //here
 			return 255;
 		}         
         return (unsigned char)p->data[sizeof(unsigned char) + sizeof(unsigned long)];


### PR DESCRIPTION
This pull request fixes an assertion failure in `GetPacketID` located in `src/Hooks.cpp`. 

The assertion p->length > sizeof(unsigned char) + sizeof(unsigned long)` was failing due to incorrect handling of packet lengths. This fix ensures the packet length is properly validated before accessing the data.

samp03svr: /home/michael/repos/SKY/src/Hooks.cpp:148: BYTE GetPacketID(Packet*): Assertion `p->length > sizeof(unsigned char) + sizeof(unsigned long)' failed.
zsh: IOT instruction  ./samp03svr

I know that this is caused by a crasher.