### PR TITLE
fix: night vision abuse and increased max world bound checks #73

### DIFF
--- a/src/game/Player.cpp
+++ b/src/game/Player.cpp
@@ -15,6 +15,9 @@ namespace Player
     DWORD lastUpdateTick[MAX_PLAYERS] = {0};
     BOOL blockKeySync[MAX_PLAYERS] = {0};
     BOOL infiniteAmmo[MAX_PLAYERS] = {0};
+    
+    DWORD gogglesTick[MAX_PLAYERS] = {0};
+    BYTE gogglesUsed[MAX_PLAYERS] = {0};
 
     BOOL syncOnFootDataFrozen[MAX_PLAYERS] = {0};     // Stores the frozen state for OnFoot Sync
     BOOL syncAimDataFrozen[MAX_PLAYERS] = {0};        // Stores the frozen state for Aim Sync

--- a/src/game/Player.h
+++ b/src/game/Player.h
@@ -21,6 +21,9 @@ namespace Player
     extern DWORD lastUpdateTick[MAX_PLAYERS];
     extern BOOL blockKeySync[MAX_PLAYERS];
     extern BOOL infiniteAmmo[MAX_PLAYERS];
+    
+    extern DWORD gogglesTick[MAX_PLAYERS];
+    extern BYTE gogglesUsed[MAX_PLAYERS];
 
     extern BOOL syncDataFrozen[MAX_PLAYERS];
     extern BOOL syncAimDataFrozen[MAX_PLAYERS];

--- a/src/game/SyncProcessing.h
+++ b/src/game/SyncProcessing.h
@@ -2,6 +2,7 @@
 
 #include "../structs/CTypes.h"
 #include "../core/Global.h"
+#include "../utils/Utils.h"
 
 namespace SyncProcessing
 {

--- a/src/game/SyncProcessing.inl
+++ b/src/game/SyncProcessing.inl
@@ -127,9 +127,24 @@ namespace SyncProcessing
         // Handle special weapon key restrictions
         if (data->byteWeapon == 44 || data->byteWeapon == 45) {
             data->wKeys &= ~4; // Remove fire key for night vision/thermal goggles
+
+            Player::gogglesTick[playerId] = GetTickCount();
+            Player::gogglesUsed[playerId] = 1;
         }
         else if (data->byteWeapon == 4 && !Global::knifeSync) {
             data->wKeys &= ~128; // Remove aim key for knife if knife sync disabled
+        } 
+        else if (Player::gogglesUsed[playerId]) {
+            DWORD currentTick = GetTickCount();
+
+            if (Player::gogglesUsed[playerId] == 2 && currentTick - Player::gogglesTick[playerId] > 40) {
+                Player::gogglesUsed[playerId] = 0;
+            } else {
+                data->wKeys &= ~4; // Remove fire key
+                
+                Player::gogglesTick[playerId] = currentTick;
+                Player::gogglesUsed[playerId] = 2;
+            }
         }
 
         Player::lastWeapon[playerId] = data->byteWeapon;

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -157,12 +157,13 @@ bool ValidatePosition(const CVector& position) {
     }
     
     // Check reasonable world bounds (San Andreas map boundaries)
-    const float MAX_COORD = 4000.0f;
-    const float MIN_COORD = -4000.0f;
+	// Original bounds where X: 4000, Y: 4000, Z: 2000
+    const float MAX_COORD = 20000.0f;
+    const float MIN_COORD = -20000.0f;
     
     if (position.fX < MIN_COORD || position.fX > MAX_COORD ||
         position.fY < MIN_COORD || position.fY > MAX_COORD ||
-        position.fZ < -100.0f || position.fZ > 2000.0f) { // Z has different bounds
+        position.fZ < -1000.0f || position.fZ > 3000.0f) { // Z has different bounds
         return false;
     }
     


### PR DESCRIPTION
This pull request introduces improvements to player sync handling, specifically for night vision and thermal goggles, and expands the allowed world boundaries for position validation. The main changes add tracking for goggles usage and timing, update the sync logic to prevent unwanted firing when goggles are equipped, and adjust map boundary checks to allow a much larger playable area.

**Player goggles sync improvements:**
* Added `gogglesTick` and `gogglesUsed` arrays to the `Player` namespace to track when goggles are equipped and how long they've been used (`Player.cpp`, `Player.h`). [[1]](diffhunk://#diff-de71a0bef2855962354cadbe36e913957a5017a1821e44753fae6db29a21f7ebR19-R21) [[2]](diffhunk://#diff-67499b11b8252a24d30dacc357a3d0a981b6db00f795b0a66d282c2b30341dcdR25-R27)
* Updated sync logic in `SyncProcessing` to block the fire key when night vision or thermal goggles are equipped, and implemented a timer-based mechanism to prevent rapid toggling or firing while goggles are active (`SyncProcessing.inl`).
* Included `Utils.h` in `SyncProcessing.h` to support new timing logic.

**World boundary expansion:**
* Increased the allowed X/Y/Z world coordinates in `ValidatePosition` to support much larger map areas, and relaxed Z-axis bounds for more vertical freedom (`Utils.cpp`).